### PR TITLE
Ensure BINDIR is created

### DIFF
--- a/makefile
+++ b/makefile
@@ -365,6 +365,8 @@ all:	lout prg2lout
 install: lout prg2lout
 	@echo ""
 	@echo "(a) Installing lout and prg2lout binaries into BINDIR $(BINDIR)"
+	$(MKDIR) $(BINDIR)
+	chmod 755 $(BINDIR)
 	cp lout $(BINDIR)/lout
 	chmod 755 $(BINDIR)/lout
 	cp prg2lout $(BINDIR)/prg2lout


### PR DESCRIPTION
It might be possible that `BINDIR` does not exists when `make install` is called, that results in an error.
Creating `BINDIR` before copying files resolves this.