### PR TITLE
tblf : fix typo in @PaintBox PDF backend

### DIFF
--- a/include/tblf
+++ b/include/tblf
@@ -1357,7 +1357,7 @@ def @TblSetup
 	    {
 	      @BackEnd @Case {
 		PostScript @Yield { {"LoutBox" @ColourCommand p t "fill"} @Graphic x }
-		PDF        @Yield { { @PDFBox @PDFAddPaint col "S" } @Graphic x }
+		PDF        @Yield { { @PDFBox @PDFAddPaint p "S" } @Graphic x }
 		PlainText  @Yield { x }
 	      }
 	    }


### PR DESCRIPTION
that simple typo was breaking  `@Cell paint {whatever}` in PDF backend
closes #4 