### PR TITLE
Avoid calling catclose with an invalid argument

### DIFF
--- a/z01.c
+++ b/z01.c
@@ -974,7 +974,8 @@ int main(int argc, char *argv[])
   while( run_num <= runs_to_do );
 
 #if LOCALE_ON
-  catclose(MsgCat);
+  if (MsgCat != (nl_catd)-1)
+    catclose(MsgCat);
 #endif
 
   exit(0);


### PR DESCRIPTION
POSIX doesn't specify that catclose should accept -1 as argument, and with musl it causes a segfault.

## Musl Libc philosophy
> Generally in musl, we prefer to trap on UB rather than allowing
> forward progress, especially when the natural default action without
> special casing it is to trap.
--- Rich Felker

## Glibc philosophy
It doesn't differ from musl's nowadays (particularly sections 10.2 and 10.4):
https://sourceware.org/glibc/wiki/Style_and_Conventions#Error_Handling